### PR TITLE
Simplify rebalance ui

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -198,8 +198,12 @@
 			            <ul>
 				            <li><b>Portfolio Value:</b> Your total investable assets. Include all accounts where stocks, bonds, and cash instruments might reside. Do not include pensions, social security, house equity or other income streams in this number.</li>
 				            <li><b>Initial Assets:</b> This is the asset allocation of your portfolio as of today. You can choose any mixture of Equities, Bonds, Gold, and Cash. <b>Please note: Gold prices were unchanged for a large period of time in the 1800's. Take this into consideration for the simulations.</b> Since there is no reliable historical data on cash investments (that I can find), the Growth of Cash input is for the user to determine how much growth over time that your cash allocation receives. As a default, it is set to 0.25%, an average value for a savings account at the credit unions in my area. Fees represent the maintenance/administrative fees that your portfolio requires. This number is calculated against your entire portfolio each year, so please use an average number across all accounts.</li> 
-				            <li><b>Rebalance Annually:</b> Choosing "Yes" will automatically rebalance your portfolio to match your chosen asset allocation. If you choose "No", your portfolio will drift to different percentages depending on how each asset class performs.</li>
-				            <li><b>Keep Allocation Constant::</b> Choosing "Yes" means that your asset allocation will remain the same throughout the simulation. Choosing "No", you can set what is commonly called a <b>Glide Path</b> allocation change. You will choose a target allocation that is different from your current one (Ex. You want to go from 80%/20% stocks/bonds to 60%/40% stocks and bonds in retirement). You will then choose a "Start Year" and "End Year" to execute this allocation change. Your allocation will slowly change to the target allocation over the course of those years.</li>
+				            <li><b>Rebalance Annually:</b> There are three options available,
+                                <ul><li><b>None</b> Your portfolio will drift to different percentages depending on how each asset class performs.</li>
+                                <li><b>Constant</b> Your portfolio will automatically rebalance  each year to match your initially chosen asset allocation.
+                                <li><b>Glide Path</b> You will choose a target allocation that is different from your initial one (For example, you want to go from 80%/20% stocks/bonds to 60%/40% stocks and bonds in retirement). You will then choose a "Start Year" and "End Year" to execute this allocation change. Your allocation will slowly change to the target allocation over the course of those years.</li>
+                                </ul>
+				            </li>
 			            </ul>
 
 		            </div>

--- a/index.html
+++ b/index.html
@@ -399,7 +399,7 @@
                                     </div>
                                 </div>
                                 <div class="col-md-6">
-                                    <div class="form-group">
+                                    <!--div class="form-group">
                                         <label>
                                             Keep Allocation Constant:
                                             <select class="form-control"
@@ -407,7 +407,7 @@
                                                     ng-change="refreshConstantAllocationOptions()"
                                                     ng-options="constantAllocationOptions.value as constantAllocationOptions.text for constantAllocationOptions in constantAllocationOptionsTypes"></select>
                                         </label>
-                                    </div>
+                                    </div-->
                                 </div>
                             </div>
                             <div class="panel panel-default" id="targetAssets" style="display:none">
@@ -1495,7 +1495,7 @@
                         percentCash: 0,
                         percentFees: 0.18,
                         growthOfCash: 0.25,
-                        rebalanceAnnually: true,
+                        rebalanceAnnually: 1,
                         constantAllocation: true,
                         changeAllocationStartYear: 2025,
                         changeAllocationEndYear: 2030,
@@ -1642,12 +1642,16 @@
                     ]
                 }]
                 $scope.rebalanceAnnuallyOptionsTypes = [{
-                    text: 'Yes',
-                    value: true
+                    text: 'None',
+                    value: 0
                 },
                 {
-                    text: 'No',
-                    value: false
+                    text: 'Constant',
+                    value: 1
+                },
+                {
+                    text: 'Glidepath',
+                    value: 2
                 }]
                 $scope.constantAllocationOptionsTypes = [{
                     text: 'Yes',
@@ -1881,24 +1885,10 @@
                     // $scope.data =
                     //Load from JSON
                 }
-                // TODO: Could these 2 be turned into declarative Angular statements?
                 $scope.refreshRebalanceAnnuallyOptions = function () {
-                    if ($scope.data.portfolio.rebalanceAnnually == false) {
-                        $('select[ng-model="data.portfolio.constantAllocation"]').attr('disabled', true);
-                        $('select[ng-model="data.portfolio.constantAllocation"]').val("0");
-                    } else {
-                        $('select[ng-model="data.portfolio.constantAllocation"]').attr('disabled', false);
-                        $('select[ng-model="data.portfolio.constantAllocation"]').val("0");
-                    }
-                }
-                $scope.refreshConstantAllocationOptions = function () {
-                    if ($scope.data.portfolio.constantAllocation == false) {
-                        $('select[ng-model="data.portfolio.rebalanceAnnually"]').attr('disabled', true);
-                        $('select[ng-model="data.portfolio.rebalanceAnnually"]').val("0");
+                    if ($scope.data.portfolio.rebalanceAnnually == 2) {
                         $('#targetAssets').show();
                     } else {
-                        $('select[ng-model="data.portfolio.rebalanceAnnually"]').attr('disabled', false);
-                        $('select[ng-model="data.portfolio.rebalanceAnnually"]').val("0");
                         $('#targetAssets').hide();
                     }
                 }

--- a/index.html
+++ b/index.html
@@ -398,17 +398,6 @@
                                         </label>
                                     </div>
                                 </div>
-                                <div class="col-md-6">
-                                    <!--div class="form-group">
-                                        <label>
-                                            Keep Allocation Constant:
-                                            <select class="form-control"
-                                                    ng-model="data.portfolio.constantAllocation"
-                                                    ng-change="refreshConstantAllocationOptions()"
-                                                    ng-options="constantAllocationOptions.value as constantAllocationOptions.text for constantAllocationOptions in constantAllocationOptionsTypes"></select>
-                                        </label>
-                                    </div-->
-                                </div>
                             </div>
                             <div class="panel panel-default" id="targetAssets" style="display:none">
                                 <div class="panel-heading">
@@ -1496,7 +1485,6 @@
                         percentFees: 0.18,
                         growthOfCash: 0.25,
                         rebalanceAnnually: 1,
-                        constantAllocation: true,
                         changeAllocationStartYear: 2025,
                         changeAllocationEndYear: 2030,
                         targetPercentEquities: 100,
@@ -1652,14 +1640,6 @@
                 {
                     text: 'Glidepath',
                     value: 2
-                }]
-                $scope.constantAllocationOptionsTypes = [{
-                    text: 'Yes',
-                    value: true
-                },
-                {
-                    text: 'No',
-                    value: false
                 }]
                 $scope.spendingPlanTypes = [{
                     text: 'Inflation Adjusted',

--- a/js/cFIREsimOpen.js
+++ b/js/cFIREsimOpen.js
@@ -303,13 +303,28 @@ var Simulation = {
     		"gold": null,
     		"cash": null
     	};
-		if(form.portfolio.rebalanceAnnually > 0){ //anything form of rebalance
-			if(form.portfolio.rebalanceAnnually == 1){ //constant
+        switch(form.portfolio.rebalanceAnnually){
+            case 0: //no rebalance
+                if(j>0){
+                    var prev = j - 1;
+                    ret.equities = this.sim[i][prev].equities.end / this.sim[i][prev].portfolio.end;
+                    ret.bonds = this.sim[i][prev].bonds.end / this.sim[i][prev].portfolio.end;
+                    ret.gold = this.sim[i][prev].gold.end / this.sim[i][prev].portfolio.end;
+                    ret.cash = this.sim[i][prev].cash.end / this.sim[i][prev].portfolio.end;
+                }else{
+                    ret.equities = form.portfolio.percentEquities / 100;
+                    ret.bonds = form.portfolio.percentBonds / 100;
+                    ret.gold = form.portfolio.percentGold / 100;
+                    ret.cash = form.portfolio.percentCash / 100;
+                }
+                break;
+            case 1: //constant
 	    		ret.equities = form.portfolio.percentEquities / 100;
 	    		ret.bonds = form.portfolio.percentBonds / 100;
 	    		ret.gold = form.portfolio.percentGold / 100;
 	    		ret.cash = form.portfolio.percentCash / 100;
-    		}else{//Glide path logic
+                break;
+            case 2: //Glide path logic
     			var currentYear = new Date().getFullYear();
     			var range = {
     				"start": (form.portfolio.changeAllocationStartYear - currentYear),
@@ -336,21 +351,7 @@ var Simulation = {
 		    		ret.gold = form.portfolio.targetPercentGold / 100;
 		    		ret.cash = form.portfolio.targetPercentCash / 100;
     			}
-    		}
-		}else{ //no rebalance
-    		if(j>0){
-	    		var prev = j - 1;
-	    		ret.equities = this.sim[i][prev].equities.end / this.sim[i][prev].portfolio.end;
-	    		ret.bonds = this.sim[i][prev].bonds.end / this.sim[i][prev].portfolio.end;
-	    		ret.gold = this.sim[i][prev].gold.end / this.sim[i][prev].portfolio.end;
-	    		ret.cash = this.sim[i][prev].cash.end / this.sim[i][prev].portfolio.end;
-    		}else{
-    			ret.equities = form.portfolio.percentEquities / 100;
-	    		ret.bonds = form.portfolio.percentBonds / 100;
-	    		ret.gold = form.portfolio.percentGold / 100;
-	    		ret.cash = form.portfolio.percentCash / 100;
-    		}
-    	}
+        }
     	return ret;
     },
     calcMarketGains: function(form, i, j) {

--- a/js/cFIREsimOpen.js
+++ b/js/cFIREsimOpen.js
@@ -303,8 +303,8 @@ var Simulation = {
     		"gold": null,
     		"cash": null
     	};
-    	if(form.portfolio.rebalanceAnnually == true){
-    		if(form.portfolio.constantAllocation == true){
+		if(form.portfolio.rebalanceAnnually > 0){ //anything form of rebalance
+			if(form.portfolio.rebalanceAnnually == 1){ //constant
 	    		ret.equities = form.portfolio.percentEquities / 100;
 	    		ret.bonds = form.portfolio.percentBonds / 100;
 	    		ret.gold = form.portfolio.percentGold / 100;
@@ -337,7 +337,7 @@ var Simulation = {
 		    		ret.cash = form.portfolio.targetPercentCash / 100;
     			}
     		}
-    	}else{
+		}else{ //no rebalance
     		if(j>0){
 	    		var prev = j - 1;
 	    		ret.equities = this.sim[i][prev].equities.end / this.sim[i][prev].portfolio.end;
@@ -397,7 +397,7 @@ var Simulation = {
         this.sim[i][j].cash.end = this.roundTwoDecimals(this.sim[i][j].cash.start + this.sim[i][j].cash.growth);
     },
     calcEndPortfolio: function(form, i, j) {
-        if (form.portfolio.rebalanceAnnually == true) {
+        if (form.portfolio.rebalanceAnnually > 0) {
             var feesIncurred = this.roundTwoDecimals((this.sim[i][j].portfolio.start + this.sim[i][j].equities.growth + this.sim[i][j].bonds.growth + this.sim[i][j].cash.growth + this.sim[i][j].gold.growth) * (form.portfolio.percentFees / 100));
             this.sim[i][j].portfolio.fees = feesIncurred;
 

--- a/js/cFIREsimOpen.js
+++ b/js/cFIREsimOpen.js
@@ -398,48 +398,26 @@ var Simulation = {
         this.sim[i][j].cash.end = this.roundTwoDecimals(this.sim[i][j].cash.start + this.sim[i][j].cash.growth);
     },
     calcEndPortfolio: function(form, i, j) {
-        if (form.portfolio.rebalanceAnnually > 0) {
-            var feesIncurred = this.roundTwoDecimals((this.sim[i][j].portfolio.start + this.sim[i][j].equities.growth + this.sim[i][j].bonds.growth + this.sim[i][j].cash.growth + this.sim[i][j].gold.growth) * (form.portfolio.percentFees / 100));
-            this.sim[i][j].portfolio.fees = feesIncurred;
+        var feesIncurred = this.roundTwoDecimals((this.sim[i][j].portfolio.start + this.sim[i][j].equities.growth + this.sim[i][j].bonds.growth + this.sim[i][j].cash.growth + this.sim[i][j].gold.growth) * (form.portfolio.percentFees / 100));
+        this.sim[i][j].portfolio.fees = feesIncurred;
 
-            //Calculate current allocation percentages after all market gains are taken into consideration
-            var totalEnd = this.sim[i][j].equities.end + this.sim[i][j].bonds.end + this.sim[i][j].cash.end + this.sim[i][j].gold.end;
-            var curPercEquities = this.sim[i][j].equities.end / totalEnd;
-            var currPercCash = this.sim[i][j].cash.end / totalEnd;
-            var currPercBonds = this.sim[i][j].bonds.end / totalEnd;
-            var currPercGold = this.sim[i][j].gold.end / totalEnd;
+        //Calculate current allocation percentages after all market gains are taken into consideration
+        var totalEnd = this.sim[i][j].equities.end + this.sim[i][j].bonds.end + this.sim[i][j].cash.end + this.sim[i][j].gold.end;
+        var curPercEquities = this.sim[i][j].equities.end / totalEnd;
+        var currPercCash = this.sim[i][j].cash.end / totalEnd;
+        var currPercBonds = this.sim[i][j].bonds.end / totalEnd;
+        var currPercGold = this.sim[i][j].gold.end / totalEnd;
 
-            //Equally distribute fees and portoflio adjustments amongst portfolio based on allocation percentages
-            this.sim[i][j].equities.end = this.roundTwoDecimals(this.sim[i][j].equities.end - (curPercEquities * feesIncurred));
-            this.sim[i][j].cash.end = this.roundTwoDecimals(this.sim[i][j].cash.end - (currPercCash * feesIncurred));
-            this.sim[i][j].bonds.end = this.roundTwoDecimals(this.sim[i][j].bonds.end - (currPercBonds * feesIncurred));
-            this.sim[i][j].gold.end = this.roundTwoDecimals(this.sim[i][j].gold.end - (currPercGold * feesIncurred));
+        //Equally distribute fees and portoflio adjustments amongst portfolio based on allocation percentages
+        this.sim[i][j].equities.end = this.roundTwoDecimals(this.sim[i][j].equities.end - (curPercEquities * feesIncurred));
+        this.sim[i][j].cash.end = this.roundTwoDecimals(this.sim[i][j].cash.end - (currPercCash * feesIncurred));
+        this.sim[i][j].bonds.end = this.roundTwoDecimals(this.sim[i][j].bonds.end - (currPercBonds * feesIncurred));
+        this.sim[i][j].gold.end = this.roundTwoDecimals(this.sim[i][j].gold.end - (currPercGold * feesIncurred));
 
-            //Sum all assets to determine portfolio end value.
-            totalEnd = this.sim[i][j].equities.end + this.sim[i][j].bonds.end + this.sim[i][j].cash.end + this.sim[i][j].gold.end;
-            this.sim[i][j].portfolio.end = !isNaN(totalEnd) ? this.roundTwoDecimals(totalEnd) : 0;
-            this.sim[i][j].portfolio.infAdjEnd = parseInt(this.sim[i][j].portfolio.end / this.sim[i][j].cumulativeInflation);
-
-        } else { //Add logic for non-rebalancing portfolios
-			var feesIncurred = this.roundTwoDecimals((this.sim[i][j].portfolio.start + this.sim[i][j].equities.growth + this.sim[i][j].bonds.growth + this.sim[i][j].cash.growth + this.sim[i][j].gold.growth) * (form.portfolio.percentFees / 100));
-            this.sim[i][j].portfolio.fees = feesIncurred;
-
-            //Calculate current allocation percentages after all market gains are taken into consideration
-            var curPercEquities = this.sim[i][j].equities.end / (this.sim[i][j].equities.end + this.sim[i][j].bonds.end + this.sim[i][j].cash.end + this.sim[i][j].gold.end);
-            var currPercCash = this.sim[i][j].cash.end / (this.sim[i][j].equities.end + this.sim[i][j].bonds.end + this.sim[i][j].cash.end + this.sim[i][j].gold.end);
-            var currPercBonds = this.sim[i][j].bonds.end / (this.sim[i][j].equities.end + this.sim[i][j].bonds.end + this.sim[i][j].cash.end + this.sim[i][j].gold.end);
-            var currPercGold = this.sim[i][j].gold.end / (this.sim[i][j].equities.end + this.sim[i][j].bonds.end + this.sim[i][j].cash.end + this.sim[i][j].gold.end);
-
-            //Equally distribute fees and portoflio adjustments amongst portfolio based on allocation percentages
-            this.sim[i][j].equities.end = this.roundTwoDecimals(this.sim[i][j].equities.end - (curPercEquities * feesIncurred));
-            this.sim[i][j].cash.end = this.roundTwoDecimals(this.sim[i][j].cash.end - (currPercCash * feesIncurred));
-            this.sim[i][j].bonds.end = this.roundTwoDecimals(this.sim[i][j].bonds.end - (currPercBonds * feesIncurred));
-            this.sim[i][j].gold.end = this.roundTwoDecimals(this.sim[i][j].gold.end - (currPercGold * feesIncurred));
-
-            //Sum all assets to determine portfolio end value.
-            this.sim[i][j].portfolio.end = this.roundTwoDecimals(this.sim[i][j].equities.end + this.sim[i][j].bonds.end + this.sim[i][j].cash.end + this.sim[i][j].gold.end);
-            this.sim[i][j].portfolio.infAdjEnd = parseInt(this.sim[i][j].portfolio.end / this.sim[i][j].cumulativeInflation);
-        }
+        //Sum all assets to determine portfolio end value.
+        totalEnd = this.sim[i][j].equities.end + this.sim[i][j].bonds.end + this.sim[i][j].cash.end + this.sim[i][j].gold.end;
+        this.sim[i][j].portfolio.end = !isNaN(totalEnd) ? this.roundTwoDecimals(totalEnd) : 0;
+        this.sim[i][j].portfolio.infAdjEnd = parseInt(this.sim[i][j].portfolio.end / this.sim[i][j].cumulativeInflation);
     },
     calcFailures: function(results) {
         var totalFailures = 0;


### PR DESCRIPTION
Previously the rebalancing was sorted through two separate questions. This combines the options into one pull down menu:

* No rebalancing
* Constant allocation
* Glidepath

Current status:

* [x] Update UI to include only one pull down box.
* [x] Update the code to use the new UI
* [x] Clean up the code using the simpler options available
* [x] Update the help documents to reflect the new UI